### PR TITLE
Add eccentric anomaly determination by binary search.

### DIFF
--- a/include/astro/orbitalElementConversions.hpp
+++ b/include/astro/orbitalElementConversions.hpp
@@ -928,9 +928,5 @@ Real convertEllipticalMeanAnomalyToEccentricAnomalyBS(
  *      2007.
  *  Musegaas, P. Optimization of Space Trajectories Including Multiple Gravity Assists and Deep
  *      Space Maneuvers. MSc thesis, Delft University of Technology, 2013.
- *  TODO: in the text Meeus actually references Roger W. Sinnott's Sky & Telescope which was published
- *      a few years earlier. I have not yet been able to locate a copy to confirm the algorithm exists
- *      there as it does in AA, but this reference should likely be updated to the original developer
- *      of the algorithm rather than Meeus' redistribution of it.
- *  Meeus, J. Astronomical Algorithms. Second Edition, Willmann-Bell, Inc. 1991
+ *  Meeus, J. Astronomical Algorithms. Second Edition, Willmann-Bell, Inc. 1991.
  */

--- a/include/astro/orbitalElementConversions.hpp
+++ b/include/astro/orbitalElementConversions.hpp
@@ -928,5 +928,9 @@ Real convertEllipticalMeanAnomalyToEccentricAnomalyBS(
  *      2007.
  *  Musegaas, P. Optimization of Space Trajectories Including Multiple Gravity Assists and Deep
  *      Space Maneuvers. MSc thesis, Delft University of Technology, 2013.
- *  TODO: fill out reference! from Astronomical Algorithms p. 206
+ *  TODO: in the text Meeus actually references Roger W. Sinnott's Sky & Telescope which was published
+ *      a few years earlier. I have not yet been able to locate a copy to confirm the algorithm exists
+ *      there as it does in AA, but this reference should likely be updated to the original developer
+ *      of the algorithm rather than Meeus' redistribution of it.
+ *  Meeus, J. Astronomical Algorithms. Second Edition, Willmann-Bell, Inc. 1991
  */

--- a/include/astro/orbitalElementConversions.hpp
+++ b/include/astro/orbitalElementConversions.hpp
@@ -848,11 +848,6 @@ Real convertEllipticalMeanAnomalyToEccentricAnomaly(
     return eccentricAnomaly;
 }
 
-// TODO: where the hell to put this ?
-template <typename T> int sign(T val) {
-    return (T(0) < val) - (val < T(0));
-}
-
 //! Convert elliptical mean anomaly to eccentric anomaly using a binary search.
 /*!
  * Converts mean anomaly to eccentric anomaly for elliptical orbits,
@@ -892,8 +887,8 @@ Real convertEllipticalMeanAnomalyToEccentricAnomalyBS(
 
     const int iterations = 33;
 
-    // 110 F = SGN(M) : M = ABS(M)/(2*PI)
-    Real F = sign(M);
+    // TODO: sign(M). This is used twice in the algorithm, and could be extracted to a separate function.
+    Real F = (Real(0) < M) - (M < Real(0));
     M = fabs(M) / (2.0 * pi);
     // 120 M = (M-INT(M))*2*PI*F
     M = (M - (int)M) * 2.0 * pi * F;
@@ -922,11 +917,11 @@ Real convertEllipticalMeanAnomalyToEccentricAnomalyBS(
         // 190 M1 = E0 - E*SIN(E0)
         Real M1 = E0 - E * sin(E0);
         // 200 E0 = E0 + D*SGN(M-M1) : D = D/2
-        E0 = E0 + D * sign(M - M1);
+        Real val = M - M1;
+        E0 = E0 + D * ((Real(0) < val) - (val < Real(0)));
         D *= 0.5;
     }
 
-    // 220 E0 = E0*F
     E0 *= F;
 
     return E0;

--- a/include/astro/orbitalElementConversions.hpp
+++ b/include/astro/orbitalElementConversions.hpp
@@ -856,17 +856,22 @@ Real convertEllipticalMeanAnomalyToEccentricAnomaly(
  * If the eccentricity falls outside the valid range, then a runtime
  * exception is thrown.
  *
+ * A binary search with 100 iterations should yield about 32 bits of precision.
+ *
  * Also, note that the mean anomaly is automatically transformed to fit within the 0 to 2.0pi range.
  *
  * @tparam    Real                  Real number type
+ * @tparam    Integer               Integer type
  * @param     eccentricity          Eccentricity                                               [-]
  * @param     meanAnomaly           Mean anomaly                                               [rad]
+ * @param     iterations            Binary search iterations                                   [-]
  * @return                          Eccentric anomaly                                          [rad]
  */
-template <typename Real>
+template <typename Real, typename Integer>
 Real convertEllipticalMeanAnomalyToEccentricAnomalyBS(
-        const Real      eccentricity,
-        const Real      meanAnomaly)
+    const Real      eccentricity,
+    const Real      meanAnomaly,
+    const Integer   iterations = 100)
 {
     assert(eccentricity >= 0.0 && eccentricity < 1.0);
 
@@ -883,10 +888,6 @@ Real convertEllipticalMeanAnomalyToEccentricAnomalyBS(
     Real E = eccentricity;
     Real E0;
     Real D;
-
-    // TODO: 33 iterations gets us to the limit of accuracy for a 10bit computer. We live in the
-    // future now, how many iterations do we need to get 64 bits of accuracy?
-    const int iterations = 33;
 
     // TODO: sign(M). This is used twice in the algorithm, and could be extracted to a separate function.
     Real F = (Real(0) < M) - (M < Real(0));

--- a/include/astro/orbitalElementConversions.hpp
+++ b/include/astro/orbitalElementConversions.hpp
@@ -881,7 +881,6 @@ Real convertEllipticalMeanAnomalyToEccentricAnomalyBS(
 
     Real M = meanAnomalyShifted;
     Real E = eccentricity;
-    // estimate for eccentric offset E
     Real E0;
     Real D;
 
@@ -890,33 +889,24 @@ Real convertEllipticalMeanAnomalyToEccentricAnomalyBS(
     // TODO: sign(M). This is used twice in the algorithm, and could be extracted to a separate function.
     Real F = (Real(0) < M) - (M < Real(0));
     M = fabs(M) / (2.0 * pi);
-    // 120 M = (M-INT(M))*2*PI*F
     M = (M - (int)M) * 2.0 * pi * F;
-    // 130 IF M < 0 THEN M = M+2*PI
     if (M < 0)
     {
         M = M + 2.0 * pi;
     }
 
-    // 140 F = 1
     F = 1.0;
-    // 150 IF M > PI THEN F = -1
-    // 160 IF M > PI THEN M = 2*PI - M
     if (M > pi)
     {
         F = -1.0;
         M = 2.0 * pi - M;
     }
 
-    // 170 E0 = PI/2 : D = PI/4
     E0 = pi * 0.5;
     D = pi * 0.25;
-    // 180 FOR J = 1 TO 33
     for (int J = 0; J < iterations; J++)
     {
-        // 190 M1 = E0 - E*SIN(E0)
         Real M1 = E0 - E * sin(E0);
-        // 200 E0 = E0 + D*SGN(M-M1) : D = D/2
         Real val = M - M1;
         E0 = E0 + D * ((Real(0) < val) - (val < Real(0)));
         D *= 0.5;

--- a/include/astro/orbitalElementConversions.hpp
+++ b/include/astro/orbitalElementConversions.hpp
@@ -884,6 +884,8 @@ Real convertEllipticalMeanAnomalyToEccentricAnomalyBS(
     Real E0;
     Real D;
 
+    // TODO: 33 iterations gets us to the limit of accuracy for a 10bit computer. We live in the
+    // future now, how many iterations do we need to get 64 bits of accuracy?
     const int iterations = 33;
 
     // TODO: sign(M). This is used twice in the algorithm, and could be extracted to a separate function.

--- a/include/astro/orbitalElementConversions.hpp
+++ b/include/astro/orbitalElementConversions.hpp
@@ -853,15 +853,27 @@ template <typename T> int sign(T val) {
     return (T(0) < val) - (val < T(0));
 }
 
-// TODO: nice and cool documentation !
-// what is the problem with the newton's method approach?
-//
+//! Convert elliptical mean anomaly to eccentric anomaly using a binary search.
+/*!
+ * Converts mean anomaly to eccentric anomaly for elliptical orbits,
+ * for all eccentricities >= 0.0 and < 1.0.
+ *
+ * If the eccentricity falls outside the valid range, then a runtime
+ * exception is thrown.
+ *
+ * Also, note that the mean anomaly is automatically transformed to fit within the 0 to 2.0pi range.
+ *
+ * @tparam    Real                  Real number type
+ * @param     eccentricity          Eccentricity                                               [-]
+ * @param     meanAnomaly           Mean anomaly                                               [rad]
+ * @return                          Eccentric anomaly                                          [rad]
+ */
 template <typename Real>
 Real convertEllipticalMeanAnomalyToEccentricAnomalyBS(
         const Real      eccentricity,
         const Real      meanAnomaly)
 {
-    assert(eccentricity >= 0.0 && eccentricity < (1.0 - 1.0e-11));
+    assert(eccentricity >= 0.0 && eccentricity < 1.0);
 
     const Real pi = 3.14159265358979323846;
 


### PR DESCRIPTION
# Background

The eccentric anomaly _E_ is normally calculated using Newton-Rhapson (NR). This method is straightforward to understand and implement, and usually converges on a good result in a few iterations. The accuracy of the result can be increased by running the method for an arbitrarily large number of iterations.

# Problem

Real-time contexts, such as interactive simulations or games the worst-case performance of an algorithm becomes more important than the best or average case, as there may be severe constraints on per-frame processing budgets. An iterative method such as NR must therefore be capped in its maximum number of iterations according to the maximum allowed budget. We must allow for the worst case high-iteration outcome if using NR, as it uses a variable number of iterations depending on the input values of the orbit's eccentricity and the mean anomaly. This makes for inefficient processing, as most of the time NR resolves quickly, but the rest of the application must be restricted so as to allow NR to converge with reasonable accuracy in the worst case.

# Solution

In _Astronomical Algorithms_ a method is described to determine _E_ using a binary search (BS). The BS resolves in a constant number of iterations. As a consequence, the best- and average-cases take longer to compute than NR. However, in the worst case, BS far outperforms NR in terms of accuracy per computational cost. Since BS resolves in constant time, it is also much easier to budget for, as it is highly predictable.
